### PR TITLE
Improve table of contents markup

### DIFF
--- a/carmen_nova.xml
+++ b/carmen_nova.xml
@@ -125,12 +125,12 @@
       <div type="contents">
         <head>Inhalt</head>
         <list>
-          <item>Mystifikationen des Stils (Stephen Pegalius) <ptr target="#5"/></item>
-          <item>Carmen Nova (Umberto Eco) <ptr target="#7"/></item>
-          <item>Editorische Notiz <ptr target="#52"/></item>
-          <item>Anmerkungen des Übersetzers <ptr target="#55"/></item>
-          <item>Nachwort von Roland Barthes <ptr target="#57"/></item>
-          <item>Auszüge aus einem Interview mit Umberto Eco <ptr target="#61"/></item>
+          <item>Mystifikationen des Stils (Stephen Pegalius) <ref target="#p5">5</ref></item>
+          <item>Carmen Nova (Umberto Eco) <ref target="#p7">7</ref></item>
+          <item>Editorische Notiz <ref target="#p52">52</ref></item>
+          <item>Anmerkungen des Übersetzers <ref target="#p55">55</ref></item>
+          <item>Nachwort von Roland Barthes <ref target="#p57">57</ref></item>
+          <item>Auszüge aus einem Interview mit Umberto Eco <ref target="#p61">61</ref></item>
         </list>
       </div>
       <pb n="4"/>


### PR DESCRIPTION
This PR fixes the broken targets in the TOC page numbers. 

- Referenced `<pb>` elements were given an ID of `p{n}`. 
- TOC `<ptr>` were replaced with `<ref>` to reflect their text content.

This could be done in a more structured way with [Canonical References](https://www.tei-c.org/release/doc/tei-p5-doc/en/html/SA.html#SACR), but the definitions markup would probably be larger than our changes for these six cases. 

Changes were confirmed to work in our HTML representation.